### PR TITLE
Base64 support update

### DIFF
--- a/ExtPlaneJs.js
+++ b/ExtPlaneJs.js
@@ -11,6 +11,7 @@ var EventEmitter = require('events').EventEmitter;
 var client = require('./client');
 var util = require('util');
 var async = require('async');
+var base64 = require('base-64');
 
 function ExtPlaneJs(config){
 
@@ -146,9 +147,9 @@ function ExtPlaneJs(config){
                 return JSON.parse(value);
             break;
 
-            // data
+            // base64 data
             case 'b':
-                atob(value);
+                return base64.decode(value);
             break;
 
             default:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "assert": "^1.3.0",
     "async": "^1.4.2",
+    "base-64": "^0.1.0",
     "mocha": "^2.3.3"
   },
   "license": "MIT"


### PR DESCRIPTION
Updated base64 value parsing. 

The previously used `atob` is dependent on a DOM instance and does not work in non-browser scripts (e.g. running `node example.js`). 